### PR TITLE
Feat: Removed where_class argument

### DIFF
--- a/django_permanent/related.py
+++ b/django_permanent/related.py
@@ -8,20 +8,13 @@ from .query import AllWhereNode, DeletedWhereNode
 
 
 def get_extra_restriction_patch(func):
-    def wrapper(self, where_class, alias, lhs):
-        cond = func(self, where_class, alias, lhs)
+    def wrapper(self, alias, lhs):
+        cond = func(self, alias, lhs)
 
         from .models import PermanentModel
 
-        if not issubclass(self.model, PermanentModel) or issubclass(
-            where_class, AllWhereNode
-        ):
+        if not issubclass(self.model, PermanentModel):
             return cond
-
-        if issubclass(where_class, DeletedWhereNode):
-            cond = cond or ~where_class()
-        else:
-            cond = cond or where_class()
 
         field = self.model._meta.get_field(settings.FIELD)
 

--- a/django_permanent/related.py
+++ b/django_permanent/related.py
@@ -1,42 +1,8 @@
-from django.db.models.fields.related import ForeignObject
 from django.db.models.fields.related_descriptors import (
     ForwardManyToOneDescriptor as Descriptor,
 )
 
 from . import settings
-from .query import AllWhereNode, DeletedWhereNode
-
-
-def get_extra_restriction_patch(func):
-    def wrapper(self, alias, lhs):
-        cond = func(self, alias, lhs)
-
-        from .models import PermanentModel
-
-        if not issubclass(self.model, PermanentModel):
-            return cond
-
-        field = self.model._meta.get_field(settings.FIELD)
-
-        from django.db.models.expressions import Col
-
-        if settings.FIELD_DEFAULT is None:
-            lookup = field.get_lookup("isnull")(Col(lhs, field, field), True)
-        else:
-            lookup = field.get_lookup("exact")(
-                Col(lhs, field, field), settings.FIELD_DEFAULT
-            )
-
-        cond.add(lookup, "AND")
-
-        return cond
-
-    return wrapper
-
-
-ForeignObject.get_extra_restriction = get_extra_restriction_patch(
-    ForeignObject.get_extra_restriction
-)
 
 
 def get_queryset_patch(func):

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -166,12 +166,14 @@ class TestIntegration(TestCase):
         self.assertEqual(permanent.permanentdepended_set.count(), 1)
         self.assertEqual(PermanentDepended.objects.count(), 1)
 
+    @pytest.mark.xfail
     def test_m2m_manager(self):
         _from = M2MFrom.objects.create()
         _to = M2MTo.objects.create()
         PermanentM2MThrough.objects.create(m2m_from=_from, m2m_to=_to, removed=now())
         self.assertEqual(_from.m2mto_set.count(), 0)
 
+    @pytest.mark.xfail
     def test_m2m_manager_clear(self):
         _from = M2MFrom.objects.create()
         _to = M2MTo.objects.create()
@@ -184,9 +186,8 @@ class TestIntegration(TestCase):
         self.assertEqual(M2MFrom.objects.count(), 1)
         self.assertEqual(M2MTo.objects.count(), 1)
 
+    @pytest.mark.xfail
     def test_m2m_manager_delete(self):
-        pytest.xfail("Test is failing; probably due to django incompatibility")
-
         _from = M2MFrom.objects.create()
         _to = M2MTo.objects.create()
         PermanentM2MThrough.objects.create(m2m_from=_from, m2m_to=_to)
@@ -198,6 +199,7 @@ class TestIntegration(TestCase):
         self.assertEqual(M2MFrom.objects.count(), 1)
         self.assertEqual(M2MTo.objects.count(), 0)
 
+    @pytest.mark.xfail
     def test_m2m_prefetch_related(self):
         _from = M2MFrom.objects.create()
         _to = M2MTo.objects.create()
@@ -216,6 +218,7 @@ class TestIntegration(TestCase):
             1,
         )
 
+    @pytest.mark.xfail
     def test_m2m_all_objects(self):
         dependence = MyPermanentModel.objects.create(removed=now())
         depended = NonRemovableDepended.objects.create(
@@ -224,6 +227,7 @@ class TestIntegration(TestCase):
         depended = NonRemovableDepended.all_objects.get(pk=depended.pk)
         self.assertEqual(depended.dependence, dependence)
 
+    @pytest.mark.xfail
     def test_m2m_deleted_through(self):
         _from = M2MFrom.objects.create()
         _to = M2MTo.objects.create()


### PR DESCRIPTION
This PR removes m2m compatibility.

https://github.com/django/django/pull/14674 

This PR by django deprecated the undocumented usage of get_extra_restriction_patch and `where_class`. As such; m2m through models can no longer be soft deletable. 