### PR TITLE
PLT-1209 security(gha): Pin all github actions to a fixed sha via ratchet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 jobs:
   CI:
-    uses: uptick/actions/.github/workflows/ci.yaml@main
+    uses: uptick/actions/.github/workflows/ci.yaml@main # ratchet:exclude
     secrets: inherit
     with:
       command: make ci

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ permissions:
   issues: write
 jobs:
   Publish:
-    uses: uptick/actions/.github/workflows/ci.yaml@main
+    uses: uptick/actions/.github/workflows/ci.yaml@main # ratchet:exclude
     secrets: inherit
     with:
       uv: true


### PR DESCRIPTION
Github actions are pinned to a specific sha as part of our supply chain strategy. Merge the renovate PR to auto update the github shas. Actions without a pinned sha will no longer be allowed to run.